### PR TITLE
Refactor command front matter tags

### DIFF
--- a/_includes/command-blurbs.html
+++ b/_includes/command-blurbs.html
@@ -19,6 +19,18 @@
     <div id="{{ command_tag }}-syntax">
       <p class="command-blurb-subheader">syntax</p>
       <code>{{ command.syntax | markdownify | remove: '<p>' | remove: '</p>' }}</code>
+
+      {%- if command.alternate -%}
+      <ul id="alternates">
+        {%- for alternate in command.alternates -%}
+          <li id="alternate-item">
+            <code>get{{- command.element_type -}}{{- alternate.syntax -}}</code>: {{ alternate.description }}
+          </li>
+        {%- endfor -%}
+      </ul>
+      {%- endif -%}
+
+
     </div>
 
     <div id="{{ command_tag }}-description">
@@ -35,27 +47,13 @@
       {%- endif -%}
       {%- include collapsible-block.html content=content summary="click to expand" -%}
     </div>
-
-    
-    {%- if command.optional_parameters -%}
-    <div id="{{ command_tag }}-optional-parameters">
-      <p class="command-blurb-subheader">optional parameters</p>
-      <ul>
-        {%- for parameter in command.optional_parameters -%}
-          <li>
-            <code>{{ parameter.syntax | markdownify | remove: '<p>' | remove: '</p>' }}</code>
-          </li>
-        {%- endfor -%}
-      </ul>
-    </div>
-    {%- endif -%}
     
     {%- if command.related -%}
     <div id="{{ command_tag }}-related-commands">
       <p class="command-blurb-subheader">related commands</p>
       <ul>
         {%- for related in command.related -%}
-          {% assign related_command = site[related.collection] | where: "title", related.command | first %}
+          {% assign related_command = site[related.collection] | where: "title", related.name | first %}
           <li>
             <a href="{{ related_command.url | prepend: site.baseurl }}" target="_blank">
               <code>{{ related_command.title }}</code>

--- a/_layouts/command.html
+++ b/_layouts/command.html
@@ -25,42 +25,74 @@ layout: default
   </div>
 {% endif %}
 
-{% if page.since %}
-<h4 id="since">since</h4>
-  {{ page.since }}
-{% endif %}
+<h4 id="description">description</h4>
+{{ page.description | markdownify }}
 
 <h4 id="syntax">syntax</h4>
-{% if page.command_type == "global" and page.title != "PennController.ResetPrefix" %}
-  <code>(PennController.){{ page.syntax | markdownify | remove: '<p>' | remove: '</p>' }}</code>
-  <p id="penncontroller-prefix-meaning" class="text-delta">
+{% if page.command_type  == "global" and page.title != "PennController.ResetPrefix" %}
+  {%- assign prefix = "(PennController.)" -%}
+  {% capture message %}
+  <p id="penncontroller-prefix-meaning" class="text-delta mt-2 mb-1">
     ↳ <a href="{{site.baseurl}}/docs/faqs#penncontroller-prefix" target="_blank">
     What does <code>(PennController.)</code> mean?
     </a>
   </p>
+  {% endcapture %}
+{% elsif page.grand_parent == "Elements" %}
+  {%- capture prefix -%}
+  get{{- page.element_type -}}(<var>ELEMENT_NAME</var>)
+  {%- endcapture -%}
 {% elsif page.element_type == "standard" %}
-<code>{{ page.syntax | markdownify | remove: '<p>' | remove: '</p>' }}</code>
-  <p id="getX-meaning" class="text-delta">
+  {%- assign prefix = "getX(<var>ELEMENT_NAME</var>)" -%}
+  {% capture message %}
+  <p id="getX-meaning" class="text-delta mt-2 mb-1">
     ↳ <a href="{{site.baseurl}}/docs/faqs#get-x" target="_blank">
     What does <code>getX()</code> mean?
     </a>
   </p>
-{% else %}
-  <code>{{ page.syntax | markdownify | remove: '<p>' | remove: '</p>' }}</code>
+  {% endcapture %}
 {% endif %}
 
-<h4 id="description">description</h4>
-{{ page.description | markdownify }}
+{% if page.parameters %}
+  <code id="command-syntax-parameters">
+    {{- prefix -}}{{- page.syntax | remove_first: ")" -}}
+    {%- for parameter in page.parameters -%}
+      {% unless forloop.first %}, {% endunless %}
+      {%- if parameter.optional -%} [ {%- endif -%}
+      <var>{{- parameter.name -}}</var>
+      {%- if parameter.type -%}: {{ parameter.type }}{%- endif -%}
+      {%- if parameter.optional -%} ] {%- endif -%}
+    {%- endfor -%}
+    )
+  </code>
+  {{ message }}
+  <ul id="parameters">
+  {%- for parameter in page.parameters -%}
+    <li id="parameter">
+      <code>
+        {%- if parameter.optional -%} [ {%- endif -%}
+        <var>{{ parameter.name }}</var>
+        {%- if parameter.optional -%} ] {%- endif -%}
+      </code>
+      {% if parameter.optional %} (optional){% endif %}: {{ parameter.description | markdownify | remove: '<p>' | remove: '</p>' }}
+    </li>
+  {%- endfor -%}
+  </ul>
+{% else %}
+  <code id="command-syntax-no-parameters">{{- prefix -}}{{- page.syntax -}}</code>
+  {{ message }}
+{% endif %}
 
-{% if page.optional_parameters %}
-<h4 id="optional-parameters">optional parameters</h4>
-<div class="optional-command-information-box" markdown=1>
-  <ul>
-    {% for parameter in page.optional_parameters %}
-    <li>
-      <code>{{ parameter.syntax | markdownify | remove: '<p>' | remove: '</p>' }}</code>
-      <p class="fw-300 fs-3">
-        {{ parameter.description | markdownify | remove: '<p>' | remove: '</p>'}}
+{% if page.alternates %}
+<h4 id="alternates">alternate(s)</h4>
+<div class="optional-command-information-box">
+  <ul id="alternate-list" class="mt-2 mb-2">
+    {% for alternate in page.alternates %}
+    <li id="alternate">
+      <code>{{- prefix -}}
+        {{- alternate.syntax | markdownify | remove: '<p>' | remove: '</p>' -}}</code>
+      <p class="mt-1 mb-2 fw-300 fs-3">
+        {{ alternate.description | markdownify | remove: '<p>' | remove: '</p>'}}
       </p>
     </li>
     {% endfor %}
@@ -70,12 +102,14 @@ layout: default
 
 {% if page.methods %}
 <h4 id="methods">methods</h4>
-<div class="optional-command-information-box" markdown=1>
-  <ul>
+<div class="optional-command-information-box">
+  <ul id="method-list" class="mt-2 mb-2">
     {% for method in page.methods %}
-    <li>
-      <p><code>{{ method.syntax }}</code></p>
-      <p class="fw-300 fs-3">{{ method.description }}</p>
+    <li id="method">
+      <code>{{ method.syntax }}</code>
+      <p class="mt-1 mb-2 fw-300 fs-3">
+        {{ method.description | markdownify | remove: '<p>' | remove: '</p>'}}
+      </p>
     </li>
     {% endfor %}
   </ul>
@@ -94,7 +128,7 @@ layout: default
 <h4 id="related-commands">related commands</h4>
   <ul>
   {% for related in page.related %}
-    {% assign related_command = site[related.collection] | where: "title", related.command | first %}
+    {% assign related_command = site[related.collection] | where: "title", related.name | first %}
     <li>
       <a href="{{ related_command.url | prepend: site.baseurl }}" target="_blank">
         <code>{{ related_command.title }}</code>
@@ -104,7 +138,12 @@ layout: default
   </ul>
 {% endif %}
 
+{% if page.since %}
+<h4 id="since">since</h4>
+  {{ page.since }}
+{% endif %}
+
 <hr>
 
-<h4 id="example">example</h4>
+<h4 id="example">example(s)</h4>
 {{ content }}

--- a/_layouts/element.html
+++ b/_layouts/element.html
@@ -22,31 +22,30 @@ layout: default
 <div id="element-description" style="display: flow-root;" markdown="1">
   {% include toc-element.html element-action=element-action element-test=element-test standard-action=standard-action standard-test=standard-test %}
 
-  <h4 id="since">since</h4>
-  {{ page.since }} 
-
   <h4 id="description">description</h4>
   {{ page.description | markdownify }} 
 
   <h4 id="syntax">syntax</h4>
   <code>
-    new{{- page.title -}}("<var>ELEMENT_NAME</var>"
+    new{{- page.title -}}(<var>ELEMENT_NAME</var>: string
     {%- for parameter in page.parameters -%}
-      , {%- if parameter.optional -%}[{%- endif -%}<var>{{ parameter.name -}}</var>{%- if parameter.optional -%}]{%- endif -%}
+      , {% if parameter.optional %}[{% endif %}<var>{{ parameter.name }}</var>{% if parameter.type %}: {{ parameter.type}}{% endif %}{% if parameter.optional %}]{% endif %}
     {%- endfor -%}
     )
   </code>
-  <ul>
-    <li>
-      <code>"<var>ELEMENT_NAME</var>"</code>: The name of the newly-created element.
+  <ul id="parameters">
+    <li id="element-name-parameter">
+      <code><var>ELEMENT_NAME</var></code>: The name of the newly-created element.
     </li>
     {%- for parameter in page.parameters -%}
-      <li>
-        <code>{%- if parameter.optional -%}[{%- endif -%}<var>
-          {{- parameter.name -}}
-        </var>{%- if parameter.optional -%}]{%- endif -%}</code>
-        {% if parameter.optional %} (optional){% endif %}: {{ parameter.description | markdownify | remove: '<p>' | remove: '</p>' }}
-      </li>
+    <li id="{{ parameter.name}}-parameter">
+      <code>
+        {%- if parameter.optional -%}[{%- endif -%}
+        <var>{{- parameter.name -}}</var>
+        {%- if parameter.optional -%}]{%- endif -%}
+      </code>
+      {% if parameter.optional %} (optional){% endif %}: {{ parameter.description | markdownify | remove: '<p>' | remove: '</p>' }}
+    </li>
     {%- endfor -%}
   </ul>
 
@@ -55,15 +54,18 @@ layout: default
     {{ page.excerpt }}
   {% endif %}
 
-{% unless page.no_example %}
-  <hr>
-  <h4 id="example">example</h4>
-  {% if page.notes %}
-    {{ page.content | remove: page.excerpt }}
-  {% else %}
-    {{ page.content }}
-  {% endif %}
-{% endunless %}
+  <h4 id="since">since</h4>
+  {{ page.since }} 
+
+  {% unless page.no_example %}
+    <hr>
+    <h4 id="example">example(s)</h4>
+    {% if page.notes %}
+      {{ page.content | remove: page.excerpt }}
+    {% else %}
+      {{ page.content }}
+    {% endif %}
+  {% endunless %}
 </div>
 
 <hr>

--- a/reference/_audio/audio-disable.md
+++ b/reference/_audio/audio-disable.md
@@ -2,11 +2,12 @@
 title: audio.disable
 command_type: action
 syntax: .disable()
+parameters:
+  - name: OPACITY
+    type: float
+    description: Prints a grey rectangular layer of specified opacity onto the audio player interface, where `0.01` is completely transparent and `1` is completey opaque.
+    optional: true
 description: Disables the audio player interface controls.
-optional_parameters:
-  - syntax: .disable(*OPACITY*)
-    description: Prints a grey rectangular layer of specified opacity onto the audio player interface. 
-    note: 
 ---
 
 <pre><code class="language-diff-javascript diff-highlight">

--- a/reference/_audio/audio-log.md
+++ b/reference/_audio/audio-log.md
@@ -1,8 +1,8 @@
 ---
 title: audio.log
 command_type: action
-syntax: getAudio("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-once.md
+++ b/reference/_audio/audio-once.md
@@ -1,8 +1,8 @@
 ---
 title: audio.once
 command_type: action
-syntax: getAudio("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-pause.md
+++ b/reference/_audio/audio-pause.md
@@ -1,8 +1,8 @@
 ---
 title: audio.pause
 command_type: action
-syntax: getAudio("ELEMENT_NAME").pause()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .pause()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-play.md
+++ b/reference/_audio/audio-play.md
@@ -1,8 +1,8 @@
 ---
 title: audio.play
 command_type: action
-syntax: getAudio("ELEMENT_NAME").play()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .play()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-print.md
+++ b/reference/_audio/audio-print.md
@@ -1,8 +1,8 @@
 ---
 title: audio.print
 command_type: action
-syntax: getAudio("ELEMENT_NAME").print()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .print()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-remove.md
+++ b/reference/_audio/audio-remove.md
@@ -1,8 +1,8 @@
 ---
 title: audio.remove
 command_type: action
-syntax: getAudio("ELEMENT_NAME").remove()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .remove()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-stop.md
+++ b/reference/_audio/audio-stop.md
@@ -1,8 +1,8 @@
 ---
 title: audio.stop
 command_type: action
-syntax: getAudio("ELEMENT_NAME").stop()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .stop()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-test.hasPlayed.md
+++ b/reference/_audio/audio-test.hasPlayed.md
@@ -1,8 +1,8 @@
 ---
 title: audio.test.hasPlayed
 command_type: test
-syntax: getAudio("ELEMENT_NAME").test.hasPlayed()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.hasPlayed()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-test.playing.md
+++ b/reference/_audio/audio-test.playing.md
@@ -1,8 +1,8 @@
 ---
 title: audio.test.playing
 command_type: test
-syntax: getAudio("ELEMENT_NAME").test.playing()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.playing()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_audio/audio-wait.md
+++ b/reference/_audio/audio-wait.md
@@ -1,13 +1,14 @@
 ---
 title: audio.wait
 command_type: action
-syntax: getAudio("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-optional_parameters: 
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+alternates:
   - syntax: .wait("first")
-    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-  - syntax: .wait(*TEST_COMMAND*)
-    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  - syntax: .wait(TEST_COMMAND)
+    description: Lorem ipsum dolor sit amet, *consectetur adipiscing elit*.
+
 ---
 
 ```javascript

--- a/reference/_button/button-callback.md
+++ b/reference/_button/button-callback.md
@@ -1,8 +1,8 @@
 ---
 title: button.callback
 command_type: action
-syntax: getButton("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_button/button-click.md
+++ b/reference/_button/button-click.md
@@ -1,8 +1,8 @@
 ---
 title: button.click
 command_type: action
-syntax: getButton("ELEMENT_NAME").click()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .click()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_button/button-log.md
+++ b/reference/_button/button-log.md
@@ -1,8 +1,8 @@
 ---
 title: button.log
 command_type: action
-syntax: getButton("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_button/button-once.md
+++ b/reference/_button/button-once.md
@@ -1,8 +1,8 @@
 ---
 title: button.once
 command_type: action
-syntax: getButton("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_button/button-test.clicked.md
+++ b/reference/_button/button-test.clicked.md
@@ -1,8 +1,8 @@
 ---
 title: button.test.clicked
 command_type: test
-syntax: getButton("ELEMENT_NAME").test.clicked()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.clicked()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_button/button-wait.md
+++ b/reference/_button/button-wait.md
@@ -1,13 +1,13 @@
 ---
 title: button.wait
 command_type: action
-syntax: getButton("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-optional_parameters: 
-  - syntax: getButton("ELEMENT_NAME").wait("first")
-    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-  - syntax: getButton("ELEMENT_NAME").wait(TEST_COMMAND)
-    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+alternate: 
+  - syntax: .wait("first")
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  - syntax: .wait(TEST_COMMAND)
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_canvas/canvas-add.md
+++ b/reference/_canvas/canvas-add.md
@@ -1,8 +1,8 @@
 ---
 title: canvas.add
 command_type: action
-syntax: getCanvas("ELEMENT_NAME").add()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .add()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_canvas/canvas-color.md
+++ b/reference/_canvas/canvas-color.md
@@ -1,8 +1,8 @@
 ---
 title: canvas.color
 command_type: action
-syntax: getCanvas("ELEMENT_NAME").color()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .color()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_canvas/canvas-log.md
+++ b/reference/_canvas/canvas-log.md
@@ -1,8 +1,8 @@
 ---
 title: canvas.log
 command_type: action
-syntax: getCanvas("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_controller/controller-log.md
+++ b/reference/_controller/controller-log.md
@@ -1,8 +1,8 @@
 ---
 title: controller.log
 command_type: action
-syntax: getController("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_controller/controller-wait.md
+++ b/reference/_controller/controller-wait.md
@@ -1,8 +1,8 @@
 ---
 title: controller.wait
 command_type: action
-syntax: getController("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_deprecated/FeedItems.md
+++ b/reference/_deprecated/FeedItems.md
@@ -4,7 +4,7 @@ parent: ⚠ Global commands
 deprecated: PennController 1.0
 replacement: Template
 syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_deprecated/scale-labels.md
+++ b/reference/_deprecated/scale-labels.md
@@ -3,8 +3,8 @@ title: scale.labels
 parent: ⚠ Element commands
 deprecated: PennController 1.0
 replacement: scale.labelsPosition
-syntax: getScale("ELEMENT_NAME").labels()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .labels()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_deprecated/voicerecorder-log.md
+++ b/reference/_deprecated/voicerecorder-log.md
@@ -6,7 +6,7 @@ command_type: action
 syntax: getVoiceRecorder("ELEMENT_NAME").once()
 deprecated: PennController 1.8
 replacement: mediarecorder.log
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_deprecated/voicerecorder-once.md
+++ b/reference/_deprecated/voicerecorder-once.md
@@ -6,7 +6,7 @@ command_type: action
 syntax: getVoiceRecorder("ELEMENT_NAME").once()
 deprecated: PennController 1.8
 replacement: mediarecorder.once
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_deprecated/voicerecorder-play.md
+++ b/reference/_deprecated/voicerecorder-play.md
@@ -6,7 +6,7 @@ command_type: action
 syntax: getVoiceRecorder("ELEMENT_NAME").play()
 deprecated: PennController 1.8
 replacement: mediarecorder.play
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_deprecated/voicerecorder-record.md
+++ b/reference/_deprecated/voicerecorder-record.md
@@ -6,7 +6,7 @@ command_type: action
 deprecated: PennController 1.8
 replacement: mediarecorder.record
 syntax: getVoiceRecrder("ELEMENT_NAME").record()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_deprecated/voicerecorder-stop.md
+++ b/reference/_deprecated/voicerecorder-stop.md
@@ -6,7 +6,7 @@ command_type: action
 syntax: getVoiceRecorder("ELEMENT_NAME").stop()
 deprecated: PennController 1.8
 replacement: mediarecorder.stop
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_deprecated/voicerecorder-test.hasPlayed.md
+++ b/reference/_deprecated/voicerecorder-test.hasPlayed.md
@@ -6,7 +6,7 @@ command_type: test
 syntax: getVoiceRecorder("ELEMENT_NAME").test.hasPlayed()
 deprecated: PennController 1.8
 replacement: mediarecorder.test.hasPlayed
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_deprecated/voicerecorder-test.playing.md
+++ b/reference/_deprecated/voicerecorder-test.playing.md
@@ -6,7 +6,7 @@ command_type: test
 syntax: getVoiceRecorder("ELEMENT_NAME").test.playing()
 deprecated: PennController 1.8
 replacement: mediarecorder.test.playing
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_deprecated/voicerecorder-test.recorded.md
+++ b/reference/_deprecated/voicerecorder-test.recorded.md
@@ -6,7 +6,7 @@ command_type: test
 syntax: getVoiceRecorder("ELEMENT_NAME").test.recorded()
 deprecated: PennController 1.8
 replacement: mediarecorder.test.recorded
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_deprecated/voicerecorder-wait.md
+++ b/reference/_deprecated/voicerecorder-wait.md
@@ -6,7 +6,7 @@ command_type: action
 syntax: getVoiceRecorder("ELEMENT_NAME").wait()
 deprecated: PennController 1.8
 replacement: mediarecorder.wait
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 nav_exclude: true
 ---
 

--- a/reference/_dropdown/dropdown-add.md
+++ b/reference/_dropdown/dropdown-add.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.add
 command_type: action
-syntax: getDropDown("ELEMENT_NAME").add()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .add()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_dropdown/dropdown-callback.md
+++ b/reference/_dropdown/dropdown-callback.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.callback
 command_type: action
-syntax: getDropDown("ELEMENT_NAME").callback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .callback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_dropdown/dropdown-log.md
+++ b/reference/_dropdown/dropdown-log.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.log
 command_type: action
-syntax: getDropDown("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_dropdown/dropdown-once.md
+++ b/reference/_dropdown/dropdown-once.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.once
 command_type: action
-syntax: getDropDown("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_dropdown/dropdown-remove.md
+++ b/reference/_dropdown/dropdown-remove.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.remove
 command_type: action
-syntax: getDropDown("ELEMENT_NAME").remove()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .remove()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_dropdown/dropdown-select.md
+++ b/reference/_dropdown/dropdown-select.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.select
 command_type: action
-syntax: getDropDown("ELEMENT_NAME").select()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .select()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_dropdown/dropdown-shuffle.md
+++ b/reference/_dropdown/dropdown-shuffle.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.shuffle
 command_type: action
-syntax: getDropDown("ELEMENT_NAME").shuffle()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .shuffle()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_dropdown/dropdown-test.selected.md
+++ b/reference/_dropdown/dropdown-test.selected.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.test.selected
 command_type: test
-syntax: getDropDown("ELEMENT_NAME").test.selected()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.selected()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_dropdown/dropdown-wait.md
+++ b/reference/_dropdown/dropdown-wait.md
@@ -1,8 +1,8 @@
 ---
 title: dropdown.wait
 command_type: action
-syntax: getDropDown("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_elements/audio.md
+++ b/reference/_elements/audio.md
@@ -4,7 +4,8 @@ since: beta 0.3
 children_collection: audio
 thumbnail: audio.png
 parameters:
-  - name: '"AUDIO_FILE_NAME.MP3"'
+  - name: AUDIO_FILE_NAME
+    type: string
     description: The name of the audio file.
 description: Creates an audio player.
 notes: true

--- a/reference/_elements/button.md
+++ b/reference/_elements/button.md
@@ -4,7 +4,8 @@ since: beta 0.3
 children_collection: button
 thumbnail: button.png
 parameters:
-  - name: '"BUTTON_TEXT"'
+  - name: BUTTON_TEXT
+    type: string
     description: The text that appears on the button.
 description: Represents a clickable button.
 ---

--- a/reference/_elements/canvas.md
+++ b/reference/_elements/canvas.md
@@ -6,8 +6,10 @@ children_collection: canvas
 thumbnail: canvas.png
 parameters:
   - name: WIDTH
+    type: int
     description: The width of the `Canvas`, in pixels.
   - name: HEIGHT
+    type: int
     description: The height of the `Canvas`, in pixels.
 description: Creates a rectangular surface that other elements can be placed onto.
 notes: true

--- a/reference/_elements/controller.md
+++ b/reference/_elements/controller.md
@@ -4,9 +4,11 @@ since: PennController 1.7
 children_collection: controller
 thumbnail: controller.png
 parameters:
-  - name: '"CONTROLLER"'
+  - name: CONTROLLER
+    type: string
     description: The inserted Ibex controller.
-  - name: '"ARRAY"'
+  - name: KEY_VALUE_PAIRS
+    type: array
     description: An array of key-value pairs; see each individual Ibex controller for details.
 description: Embeds an Ibex controller.
 notes: true

--- a/reference/_elements/dropdown.md
+++ b/reference/_elements/dropdown.md
@@ -5,7 +5,8 @@ children_collection: dropdown
 thumbnail: dropdown.png
 description: Represents a drop-down list.
 parameters:
-  - name: '"DEFAULT_TEXT"'
+  - name: DEFAULT_TEXT
+    type: string
     description: To be filled in.
 notes: true
 --- 

--- a/reference/_elements/eyetracker.md
+++ b/reference/_elements/eyetracker.md
@@ -5,11 +5,13 @@ children_collection: eyetracker
 thumbnail: eyetracker.png
 parameters:
   - name: OUT_OF
-    optional: true
+    type: int
     description: To be filled in.
+    optional: true
   - name: LOOKED_AT
-    optional: true
+    type: int
     description: To be filled in.
+    optional: true
 description: Creates an eye-tracking data collector.
 ---
 

--- a/reference/_elements/html.md
+++ b/reference/_elements/html.md
@@ -4,7 +4,8 @@ since: beta 0.3
 children_collection: html
 thumbnail: html.png
 parameters:
-  - name: "HTML_FILE_NAME.HTML"
+  - name: HTML_FILE_NAME
+    type: string
     description: The name of the HTML document.
 description: Represents an HTML document.
 ---

--- a/reference/_elements/image.md
+++ b/reference/_elements/image.md
@@ -4,7 +4,8 @@ since: beta 0.3
 children_collection: image
 thumbnail: image.png
 parameters:
-  - name: "IMAGE_FILE_NAME"
+  - name: IMAGE_FILE_NAME
+    type: string
     description: The image file name, including the image file format.
 description: Represents an image.
 ---

--- a/reference/_elements/key.md
+++ b/reference/_elements/key.md
@@ -4,7 +4,8 @@ since: beta 0.3
 children_collection: key
 thumbnail: key.png
 parameters:
-  - name: "KEY_STRING"
+  - name: VALIDATING_KEYS
+    type: string
     description: A string of keyboard keys that validate the `Key` element.
 description: Creates a keypress detector.
 notes: true

--- a/reference/_elements/mediarecorder.md
+++ b/reference/_elements/mediarecorder.md
@@ -5,11 +5,11 @@ children_collection: mediarecorder
 thumbnail: mediarecorder.png
 parameters:
   - name: '"audio"'
-    optional: true
     description: Records an audio stream.{:target="_blank"}
-  - name: '"video"'
     optional: true
+  - name: '"video"'
     description: Records a video stream.
+    optional: true
 description: Creates an audio and/or video recorder. 
 notes: true
 ---

--- a/reference/_elements/scale.md
+++ b/reference/_elements/scale.md
@@ -5,6 +5,7 @@ children_collection: scale
 thumbnail: scale.png
 parameters:
   - name: NUMBER_OF_BUTTONS
+    type: int
     description: Adds the specified number of radio buttons to the element.
 description: Represents a horizontal scale.
 ---

--- a/reference/_elements/text.md
+++ b/reference/_elements/text.md
@@ -4,7 +4,8 @@ since: beta 0.3
 children_collection: text
 thumbnail: text.png
 parameters:
-  - name: '"TEXT"'
+  - name: TEXT
+    type: string
     description: The text contained by the element.
 description: Represents text.
 ---

--- a/reference/_elements/textinput.md
+++ b/reference/_elements/textinput.md
@@ -4,7 +4,8 @@ since: beta 0.3
 children_collection: textinput
 thumbnail: textinput.png
 parameters:
-  - name: '"DEFAULT_TEXT"'
+  - name: DEFAULT_TEXT
+    type: string
     description: The default text that appears in the text input box.
 description: Represents a text input box.
 ---

--- a/reference/_elements/timer.md
+++ b/reference/_elements/timer.md
@@ -5,6 +5,7 @@ children_collection: timer
 thumbnail: timer.png
 parameters:
   - name: TIMER_LENGTH
+    type: int
     description: The length of the timer, in milliseconds.
 description: Represents a timer.
 ---

--- a/reference/_elements/tooltip.md
+++ b/reference/_elements/tooltip.md
@@ -4,11 +4,13 @@ since: beta 0.3
 children_collection: tooltip
 thumbnail: tooltip.png
 parameters:
-  - name: '"TOOLTIP_TEXT"'
+  - name: TOOLTIP_TEXT
+    type: string
     description: The text that appears on the tooltip.
-  - name: "VALIDATE_TEXT"
-    optional: true
+  - name: VALIDATION_TEXT
+    type: string
     description: The text that appears on a clickable button that validates and closes the tooltip. By default, this text is the string `"OK"`.
+    optional: true
 description: Represents a tooltip.
 ---
 

--- a/reference/_elements/video.md
+++ b/reference/_elements/video.md
@@ -4,7 +4,8 @@ since: beta 0.4
 children_collection: video
 thumbnail: video.png
 parameters:
-  - name: '"VIDEO_FILE_NAME"'
+  - name: VIDEO_FILE_NAME
+    type: string
     description: The video file name, including the video file format.
 description: Creates a media player that supports video playback.
 ---

--- a/reference/_elements/youtube.md
+++ b/reference/_elements/youtube.md
@@ -4,11 +4,12 @@ since: beta 0.3
 children_collection: youtube
 thumbnail: youtube.png
 parameters:
-  - name: '"YOUTUBE_REFERENCE_CODE"'
+  - name: YOUTUBE_REFERENCE_CODE
+    type: string
     description: The YouTube video reference code (the string that comes after `watch?v=` in the YouTube video URL).
   - name: '"show controls"'
-    optional: true
     description: Enables the YouTube video player controls, which are disabled by default.
+    optional: true
 description: Creates a YouTube video player. 
 ---
 

--- a/reference/_eyetracker/eyetracker-add.md
+++ b/reference/_eyetracker/eyetracker-add.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.add
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").add()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .add()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-calibrate.md
+++ b/reference/_eyetracker/eyetracker-calibrate.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.calibrate
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").calibrate()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .calibrate()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-callback.md
+++ b/reference/_eyetracker/eyetracker-callback.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.callback
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").callback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .callback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-hideFeedback.md
+++ b/reference/_eyetracker/eyetracker-hideFeedback.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.hideFeedback
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").hideFeedback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .hideFeedback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-log.md
+++ b/reference/_eyetracker/eyetracker-log.md
@@ -1,7 +1,7 @@
 ---
 title: eyetracker.log
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").log()
+syntax: .log()
 description: This describes element-specific behavior of the standard command `standard.log`.
 ---
 

--- a/reference/_eyetracker/eyetracker-showFeedback.md
+++ b/reference/_eyetracker/eyetracker-showFeedback.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.showFeedback
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").showFeedback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .showFeedback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-start.md
+++ b/reference/_eyetracker/eyetracker-start.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.start
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").start()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .start()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-stop.md
+++ b/reference/_eyetracker/eyetracker-stop.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.stop
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").stop()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .stop()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-stopTraining.md
+++ b/reference/_eyetracker/eyetracker-stopTraining.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.stopTraining
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").stopTraining()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .stopTraining()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-test.calibrated.md
+++ b/reference/_eyetracker/eyetracker-test.calibrated.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.test.calibrated
 command_type: test
-syntax: getEyeTracker("ELEMENT_NAME").test.calibrated()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.calibrated()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-test.ready.md
+++ b/reference/_eyetracker/eyetracker-test.ready.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.test.ready
 command_type: test
-syntax: getEyeTracker("ELEMENT_NAME").test.ready()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.ready()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-test.score.md
+++ b/reference/_eyetracker/eyetracker-test.score.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.test.score
 command_type: test
-syntax: getEyeTracker("ELEMENT_NAME").test.score()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.score()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-train.md
+++ b/reference/_eyetracker/eyetracker-train.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.train
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").train()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .train()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_eyetracker/eyetracker-trainOnMouseMove.md
+++ b/reference/_eyetracker/eyetracker-trainOnMouseMove.md
@@ -1,8 +1,8 @@
 ---
 title: eyetracker.trainOnMouseMove
 command_type: action
-syntax: getEyeTracker("ELEMENT_NAME").trainOnMouseMove()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .trainOnMouseMove()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_function/function-call.md
+++ b/reference/_function/function-call.md
@@ -1,8 +1,8 @@
 ---
 title: function.call
 command_type: action
-syntax: getFunction("ELEMENT_NAME").call()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .call()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_function/function-test.is.md
+++ b/reference/_function/function-test.is.md
@@ -1,8 +1,8 @@
 ---
 title: function.test.is
 command_type: test
-syntax: getFunction("ELEMENT_NAME").test.is()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.is()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/AddHost.md
+++ b/reference/_global-commands/AddHost.md
@@ -1,7 +1,11 @@
 ---
 title: AddHost
-syntax: AddHost("*URL*")
-description: Specifies a host URL to use as a source file for when calling creating a new `Audio`, `Image`, or **Video** element. The `"URL"` argument must end in `"/"`.
+syntax: AddHost
+parameters:
+  - name: URL
+    type: string
+    description: A URL.
+description: Specifies a host URL to use as a source file for when calling creating a new `Audio`, `Image`, or `Video` element. The `URL` argument must end in `"/"`.
 notes: true
 ---
 

--- a/reference/_global-commands/AddTable.md
+++ b/reference/_global-commands/AddTable.md
@@ -1,6 +1,12 @@
 ---
 title: AddTable
-syntax: AddTable("id", csv_string)
+syntax: AddTable()
+parameters:
+  - name: ID
+    type: string
+    description: To be filled in
+  - name: CSV
+    description: to be filled in
 description: Defines a table to use with `PennController.Template`. As of PennController beta 0.4, you can directly upload a CSV file to the **Resources** or **chunk_includes** folders.
 ---
 

--- a/reference/_global-commands/CheckPreloaded.md
+++ b/reference/_global-commands/CheckPreloaded.md
@@ -1,7 +1,8 @@
 ---
 title: CheckPreloaded
 parent: Global commands
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: CheckPreloaded()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/DebugOff.md
+++ b/reference/_global-commands/DebugOff.md
@@ -1,7 +1,7 @@
 ---
 title: DebugOff
-syntax: PennController.DebugOff()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: DebugOff()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/DownloadRecordingButton.md
+++ b/reference/_global-commands/DownloadRecordingButton.md
@@ -1,7 +1,11 @@
 ---
 title: DownloadRecordingButton
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: DownloadRecordingButton()
+parameters:
+  - name: BUTTON_TEXT
+    type: string
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/EyeTrackerURL.md
+++ b/reference/_global-commands/EyeTrackerURL.md
@@ -1,7 +1,11 @@
 ---
 title: EyeTrackerURL
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: EyeTrackerURL()
+parameters:
+  - name: URL
+    type: string
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/FeedItems.md
+++ b/reference/_global-commands/FeedItems.md
@@ -1,9 +1,0 @@
----
-title: FeedItems
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
----
-
-```javascript
-// example
-```

--- a/reference/_global-commands/Footer.md
+++ b/reference/_global-commands/Footer.md
@@ -1,7 +1,10 @@
 ---
 title: Footer
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: Footer
+parameters:
+  - name: COMMAND_SEQUENCE
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/GetTable.md
+++ b/reference/_global-commands/GetTable.md
@@ -1,7 +1,11 @@
 ---
 title: GetTable
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: GetTable()
+parameters:
+  - name: TABLE_NAME
+    type: string
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/GetURLParameter.md
+++ b/reference/_global-commands/GetURLParameter.md
@@ -1,7 +1,11 @@
 ---
 title: GetURLParameter
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: GetURLParameter
+parameters:
+  - name: URL_PARAMETER
+    type: string
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/Header.md
+++ b/reference/_global-commands/Header.md
@@ -1,7 +1,10 @@
 ---
 title: Header
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: Header()
+parameters:
+  - name: COMMAND_SEQUENCE
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/InitiateRecorder.md
+++ b/reference/_global-commands/InitiateRecorder.md
@@ -1,7 +1,15 @@
 ---
 title: InitiateRecorder
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: InitiateRecorder()
+parameters:
+  - name: URL
+    type: string
+    description: To be filled in
+  - name: MESSAGE
+    type: string
+    description: To be filled in
+    optional: true
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/PreloadZip.md
+++ b/reference/_global-commands/PreloadZip.md
@@ -1,7 +1,11 @@
 ---
 title: PreloadZip
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: PreloadZip()
+parameters:
+  - name: URL
+    type: string
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/ResetPrefix.md
+++ b/reference/_global-commands/ResetPrefix.md
@@ -2,15 +2,10 @@
 title: PennController.ResetPrefix
 syntax: PennController.ResetPrefix(null)
 description: Removes the default global command prefix `PennController.`
-optional_parameters: 
-  - syntax: PennController.ResetPrefix("*PREFIX*")
-    description: Resets the default global command prefix from `PennController.` to <code>"<var>PREFIX</var>"</code>
-notes: true
+alternates:
+  - syntax: 'PennController.ResetPrefix(PREFIX: string)'
+    description: Resets the default global command prefix from `PennController.` to `PREFIX`.
 ---
-
-+ something about `PennController.Elements.`
-
-<!--more-->
 
 ```javascript
 // example

--- a/reference/_global-commands/SendResults.md
+++ b/reference/_global-commands/SendResults.md
@@ -1,7 +1,12 @@
 ---
 title: SendResults
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: SendResults()
+parameters:
+  - name: TRIAL_LABEL
+    type: string
+    description: To be filled in
+    optional: true
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/Sequence.md
+++ b/reference/_global-commands/Sequence.md
@@ -1,7 +1,10 @@
 ---
 title: Sequence
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: Sequence()
+parameters:
+  - name: TRIAL_LABELS
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/SetCounter.md
+++ b/reference/_global-commands/SetCounter.md
@@ -1,7 +1,18 @@
 ---
 title: SetCounter
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: SetCounter()
+parameters:
+  - name: TRIAL_LABEL
+    type: string
+    description: To be filled in
+    optional: true
+  - name: '"inc"'
+    description: To be filled in
+    optional: true
+  - name: INCREMENT_BY
+    type: int
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/Template.md
+++ b/reference/_global-commands/Template.md
@@ -1,7 +1,16 @@
 ---
 title: Template
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: Template
+parameters:
+  - name: TABLE_NAME
+    type: string
+    description: To be filled in
+    optional: true
+  - name: ROW_VARIABLE_NAME
+    description: To be filled in
+  - name: "=>"
+    description: To be filled in
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/UploadRecordings.md
+++ b/reference/_global-commands/UploadRecordings.md
@@ -1,8 +1,15 @@
 ---
 title: UploadRecordings
 since: PennController 1.8
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: UploadRecordings()
+parameters:
+  - name: TRIAL_LABEL
+    type: string
+    description: To be filled in
+  - name: '"noblock"'
+    description: To be filled in
+    optional: true
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_global-commands/newTrial.md
+++ b/reference/_global-commands/newTrial.md
@@ -1,16 +1,22 @@
 ---
 title: newTrial
-syntax: to be filled in
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: newTrial()
+parameters: 
+  - name: TRIAL_LABEL
+    type: string
+    description: To be filled in
+    optional: true
+  - name: COMMAND_SEQUENCE
+    description: To be filled in
 methods: 
-  - syntax: newTrial().log("COLUMN_NAME", VALUE)
-    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+  - syntax: newTrial().log(COLUMN_NAME, VALUE)
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   - syntax: newTrial().noFooter()
-    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   - syntax: newTrial().noHeader()
-    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   - syntax: newTrial().setOption(OPTION, VALUE)
-    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_html/html-checkboxWarning.md
+++ b/reference/_html/html-checkboxWarning.md
@@ -1,8 +1,8 @@
 ---
 title: html.checkboxWarning
 command_type: action
-syntax: getHtml("ELEMENT_NAME").checkboxWarning()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .checkboxWarning()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_html/html-inputWarning.md
+++ b/reference/_html/html-inputWarning.md
@@ -1,8 +1,8 @@
 ---
 title: html.inputWarning
 command_type: action
-syntax: getHtml("ELEMENT_NAME").inputWarning()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .inputWarning()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_html/html-log.md
+++ b/reference/_html/html-log.md
@@ -1,8 +1,8 @@
 ---
 title: html.log
 command_type: action
-syntax: getHtml("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_html/html-radioWarning.md
+++ b/reference/_html/html-radioWarning.md
@@ -1,8 +1,8 @@
 ---
 title: html.radioWarning
 command_type: action
-syntax: getHtml("ELEMENT_NAME").radioWarning()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .radioWarning()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_html/html-test.complete.md
+++ b/reference/_html/html-test.complete.md
@@ -1,8 +1,8 @@
 ---
 title: html.test.complete
 command_type: test
-syntax: getHtml("ELEMENT_NAME").test.complete()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.complete()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_html/html-warn.md
+++ b/reference/_html/html-warn.md
@@ -1,8 +1,8 @@
 ---
 title: html.warn
 command_type: action
-syntax: getHtml("ELEMENT_NAME").warn()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .warn()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_image/image-log.md
+++ b/reference/_image/image-log.md
@@ -1,8 +1,8 @@
 ---
 title: image.log
 command_type: action
-syntax: getImage("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_key/key-callback.md
+++ b/reference/_key/key-callback.md
@@ -1,8 +1,8 @@
 ---
 title: key.callback
 command_type: action
-syntax: getKey("ELEMENT_NAME").callback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .callback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_key/key-log.md
+++ b/reference/_key/key-log.md
@@ -1,8 +1,8 @@
 ---
 title: key.log
 command_type: action
-syntax: getKey("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_key/key-test.pressed.md
+++ b/reference/_key/key-test.pressed.md
@@ -1,8 +1,8 @@
 ---
 title: key.test.pressed
 command_type: test
-syntax: getKey("ELEMENT_NAME").test.pressed()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.pressed()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_key/key-wait.md
+++ b/reference/_key/key-wait.md
@@ -1,8 +1,8 @@
 ---
 title: key.wait
 command_type: action
-syntax: getKey("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediaRecorder-test.playing.md
+++ b/reference/_mediarecorder/mediaRecorder-test.playing.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.test.playing
 command_type: test
-syntax: getMediaRecorder("ELEMENT_NAME").playing()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .playing()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediarecorder-log.md
+++ b/reference/_mediarecorder/mediarecorder-log.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.log
 command_type: action
-syntax: getMediaRecorder("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediarecorder-once.md
+++ b/reference/_mediarecorder/mediarecorder-once.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.once
 command_type: action
-syntax: getMediaRecorder("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediarecorder-play.md
+++ b/reference/_mediarecorder/mediarecorder-play.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.play
 command_type: action
-syntax: getMediaRecorder("ELEMENT_NAME").play()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .play()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediarecorder-record.md
+++ b/reference/_mediarecorder/mediarecorder-record.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.record
 command_type: action
-syntax: getMediaRecorder("ELEMENT_NAME").record()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .record()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediarecorder-stop.md
+++ b/reference/_mediarecorder/mediarecorder-stop.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.stop
 command_type: action
-syntax: getMediaRecorder("ELEMENT_NAME").stop()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .stop()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediarecorder-test.hasPlayed.md
+++ b/reference/_mediarecorder/mediarecorder-test.hasPlayed.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.test.hasPlayed
 command_type: test
-syntax: getMediaRecorder("ELEMENT_NAME").test.hasPlayed()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.hasPlayed()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediarecorder-test.recorded.md
+++ b/reference/_mediarecorder/mediarecorder-test.recorded.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.test.recorded
 command_type: test
-syntax: getMediaRecorder("ELEMENT_NAME").test.recorded()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.recorded()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mediarecorder/mediarecorder-wait.md
+++ b/reference/_mediarecorder/mediarecorder-wait.md
@@ -1,8 +1,8 @@
 ---
 title: mediarecorder.wait
 command_type: action
-syntax: getMediaRecorder("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mousetracker/mousetracker-callback.md
+++ b/reference/_mousetracker/mousetracker-callback.md
@@ -1,8 +1,8 @@
 ---
 title: mousetracker.callback
 command_type: action
-syntax: getMouseTracker("ELEMENT_NAME").callback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .callback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mousetracker/mousetracker-log.md
+++ b/reference/_mousetracker/mousetracker-log.md
@@ -1,8 +1,8 @@
 ---
 title: mousetracker.log
 command_type: action
-syntax: getMouseTracker("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mousetracker/mousetracker-start.md
+++ b/reference/_mousetracker/mousetracker-start.md
@@ -1,8 +1,8 @@
 ---
 title: mousetracker.start
 command_type: action
-syntax: getMouseTracker("ELEMENT_NAME").start()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .start()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mousetracker/mousetracker-stop.md
+++ b/reference/_mousetracker/mousetracker-stop.md
@@ -1,8 +1,8 @@
 ---
 title: mousetracker.stop
 command_type: action
-syntax: getMouseTracker("ELEMENT_NAME").stop()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .stop()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_mousetracker/mousetracker-test.over.md
+++ b/reference/_mousetracker/mousetracker-test.over.md
@@ -1,8 +1,8 @@
 ---
 title: mousetracker.test.over
 command_type: test
-syntax: getMouseTracker("ELEMENT_NAME").test.over()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.over()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-button.md
+++ b/reference/_scale/scale-button.md
@@ -1,8 +1,8 @@
 ---
 title: scale.button
 command_type: action
-syntax: getScale("ELEMENT_NAME").button()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .button()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-callback.md
+++ b/reference/_scale/scale-callback.md
@@ -1,8 +1,8 @@
 ---
 title: scale.callback
 command_type: action
-syntax: getScale("ELEMENT_NAME").callback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .callback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-checkbox.md
+++ b/reference/_scale/scale-checkbox.md
@@ -1,8 +1,8 @@
 ---
 title: scale.checkbox
 command_type: action
-syntax: getScale("ELEMENT_NAME").checkbox()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .checkbox()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-default.md
+++ b/reference/_scale/scale-default.md
@@ -1,8 +1,8 @@
 ---
 title: scale.default
 command_type: action
-syntax: getScale("ELEMENT_NAME").default()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .default()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-horizontal.md
+++ b/reference/_scale/scale-horizontal.md
@@ -1,8 +1,8 @@
 ---
 title: scale.horizontal
 command_type: action
-syntax: getScale("ELEMENT_NAME").horizontal()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .horizontal()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-keys.md
+++ b/reference/_scale/scale-keys.md
@@ -1,8 +1,8 @@
 ---
 title: scale.keys
 command_type: action
-syntax: getScale("ELEMENT_NAME").keys()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .keys()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-label.md
+++ b/reference/_scale/scale-label.md
@@ -1,8 +1,8 @@
 ---
 title: scale.label
 command_type: action
-syntax: getScale("ELEMENT_NAME").label()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .label()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-labelsPosition.md
+++ b/reference/_scale/scale-labelsPosition.md
@@ -1,8 +1,8 @@
 ---
 title: scale.labelsPosition
 command_type: action
-syntax: getScale("ELEMENT_NAME").labelsPosition()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .labelsPosition()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-log.md
+++ b/reference/_scale/scale-log.md
@@ -1,8 +1,8 @@
 ---
 title: scale.log
 command_type: action
-syntax: getScale("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-once.md
+++ b/reference/_scale/scale-once.md
@@ -1,8 +1,8 @@
 ---
 title: scale.once
 command_type: action
-syntax: getScale("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-radio.md
+++ b/reference/_scale/scale-radio.md
@@ -1,8 +1,8 @@
 ---
 title: scale.radio
 command_type: action
-syntax: getScale("ELEMENT_NAME").radio()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .radio()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-select.md
+++ b/reference/_scale/scale-select.md
@@ -1,8 +1,8 @@
 ---
 title: scale.select
 command_type: action
-syntax: getScale("ELEMENT_NAME").select()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .select()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-slider.md
+++ b/reference/_scale/scale-slider.md
@@ -1,8 +1,8 @@
 ---
 title: scale.slider
 command_type: action
-syntax: getScale("ELEMENT_NAME").slider()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .slider()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-test.selected.md
+++ b/reference/_scale/scale-test.selected.md
@@ -1,8 +1,8 @@
 ---
 title: scale.test.selected
 command_type: test
-syntax: getScale("ELEMENT_NAME").test.selected()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.selected()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-unselect.md
+++ b/reference/_scale/scale-unselect.md
@@ -1,8 +1,8 @@
 ---
 title: scale.unselect
 command_type: action
-syntax: getScale("ELEMENT_NAME").unselect()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .unselect()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-vertical.md
+++ b/reference/_scale/scale-vertical.md
@@ -1,8 +1,8 @@
 ---
 title: scale.vertical
 command_type: action
-syntax: getScale("ELEMENT_NAME").vertical()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .vertical()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_scale/scale-wait.md
+++ b/reference/_scale/scale-wait.md
@@ -1,8 +1,8 @@
 ---
 title: scale.wait
 command_type: action
-syntax: getScale("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-add.md
+++ b/reference/_selector/selector-add.md
@@ -1,8 +1,8 @@
 ---
 title: selector.add
 command_type: action
-syntax: getSelector("ELEMENT_NAME").add()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .add()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-callback.md
+++ b/reference/_selector/selector-callback.md
@@ -1,8 +1,8 @@
 ---
 title: selector.callback
 command_type: action
-syntax: getSelector("ELEMENT_NAME").callback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .callback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-disableClicks.md
+++ b/reference/_selector/selector-disableClicks.md
@@ -1,8 +1,8 @@
 ---
 title: selector.disableClicks
 command_type: action
-syntax: getSelector("ELEMENT_NAME").disableClicks()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .disableClicks()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-enableClicks.md
+++ b/reference/_selector/selector-enableClicks.md
@@ -1,8 +1,8 @@
 ---
 title: selector.enableClicks
 command_type: action
-syntax: getSelector("ELEMENT_NAME").enableClicks()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .enableClicks()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-frame.md
+++ b/reference/_selector/selector-frame.md
@@ -1,8 +1,8 @@
 ---
 title: selector.frame
 command_type: action
-syntax: getSelector("ELEMENT_NAME").frame()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .frame()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-keys.md
+++ b/reference/_selector/selector-keys.md
@@ -1,8 +1,8 @@
 ---
 title: selector.keys
 command_type: action
-syntax: getSelector("ELEMENT_NAME").keys()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .keys()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-log.md
+++ b/reference/_selector/selector-log.md
@@ -1,8 +1,8 @@
 ---
 title: selector.log
 command_type: action
-syntax: getSelector("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-once.md
+++ b/reference/_selector/selector-once.md
@@ -1,8 +1,8 @@
 ---
 title: selector.once
 command_type: action
-syntax: getSelector("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-select.md
+++ b/reference/_selector/selector-select.md
@@ -1,8 +1,8 @@
 ---
 title: selector.select
 command_type: action
-syntax: getSelector("ELEMENT_NAME").select()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .select()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-shuffle.md
+++ b/reference/_selector/selector-shuffle.md
@@ -1,8 +1,8 @@
 ---
 title: selector.shuffle
 command_type: action
-syntax: getSelector("ELEMENT_NAME").shuffle()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .shuffle()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-test.index.md
+++ b/reference/_selector/selector-test.index.md
@@ -1,8 +1,8 @@
 ---
 title: selector.test.index
 command_type: test
-syntax: getSelector("ELEMENT_NAME").test.index()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.index()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-test.selected.md
+++ b/reference/_selector/selector-test.selected.md
@@ -1,8 +1,8 @@
 ---
 title: selector.test.selected
 command_type: test
-syntax: getSelector("ELEMENT_NAME").test.selected()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.selected()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-unselect.md
+++ b/reference/_selector/selector-unselect.md
@@ -1,8 +1,8 @@
 ---
 title: selector.unselect
 command_type: action
-syntax: getSelector("ELEMENT_NAME").unselect()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .unselect()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_selector/selector-wait.md
+++ b/reference/_selector/selector-wait.md
@@ -1,8 +1,8 @@
 ---
 title: selector.wait
 command_type: action
-syntax: getSelector("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-after.md
+++ b/reference/_standard-element-commands/standard-after.md
@@ -2,7 +2,10 @@
 title: standard.after
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("*ELEMENT_NAME*").after(getX("*ARGUMENT_NAME*"))
+syntax: .after()
+parameters: 
+  - name: ELEMENT
+    description: To be filled in
 description: Takes an element as an argument, and adds that element's content to the right of the element that the command is called on.
 related:
   - name: standard.before

--- a/reference/_standard-element-commands/standard-before.md
+++ b/reference/_standard-element-commands/standard-before.md
@@ -2,7 +2,10 @@
 title: standard.before
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("*ELEMENT_NAME*").before(getX("*ARGUMENT_NAME*"))
+syntax: .before()
+parameters:
+  - name: ELEMENT
+    description: To be filled in
 description: Takes an element as an argument, and adds that element's content to the left of the element that the command is called on.
 related:
   - name: standard.after

--- a/reference/_standard-element-commands/standard-bold.md
+++ b/reference/_standard-element-commands/standard-bold.md
@@ -2,7 +2,7 @@
 title: standard.bold
 command_type: action
 relevant_elements: [Button, Controller, DropDown, Html, MediaRecorder, Scale, Text, Tooltip]
-syntax: getX("*ELEMENT_NAME*").bold()
+syntax: .bold()
 description: Bolds any text that appears in the element.
 ---
 

--- a/reference/_standard-element-commands/standard-center.md
+++ b/reference/_standard-element-commands/standard-center.md
@@ -2,7 +2,7 @@
 title: standard.center
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("*ELEMENT_NAME*").center()
+syntax: .center()
 description: Horizontally centers the element.
 ---
 

--- a/reference/_standard-element-commands/standard-css.md
+++ b/reference/_standard-element-commands/standard-css.md
@@ -2,10 +2,17 @@
 title: standard.css
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("*ELEMENT_NAME*").css("*CSS_PROPERTY*", "*VALUE*")
+syntax: .css()
+parameters:
+  - name: CSS_PROPERTY
+    type: string
+    description: To be filled in
+  - name: VALUE
+    type: string
+    description: To be filled in
 description: Applies the specified CSS property and value pair to the element.
-optional_parameters: 
-  - syntax: getX("*ELEMENT_NAME*").css({"*CSS_PROPERTY_1*":"*VALUE_1*", "*CSS_PROPERTY_2*":"*VALUE_2*"})
+alternates: 
+  - syntax: '.css({"*CSS_PROPERTY_1*":"*VALUE_1*", "*CSS_PROPERTY_2*":"*VALUE_2*"})'
     description: Apply multiple CSS property and value pairs by using curly brackets and colons.
 related:
   - name: standard.cssContainer

--- a/reference/_standard-element-commands/standard-cssContainer.md
+++ b/reference/_standard-element-commands/standard-cssContainer.md
@@ -2,10 +2,17 @@
 title: standard.cssContainer
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("*ELEMENT_NAME*").cssContainer("*CSS_PROPERTY*", "*VALUE*")
+syntax: .cssContainer()
+parameters:
+  - name: CSS_PROPERTY
+    type: string
+    description: To be filled in
+  - name: VALUE
+    type: string
+    description: To be filled in
 description: Applies the specified CSS property and value pair to the container of the element.
-optional_parameters: 
-  - syntax: getX("*ELEMENT_NAME*").cssContainer({"*CSS_PROPERTY_1*":"*VALUE_1*", "*CSS_PROPERTY_2*":"*VALUE_2*"})
+alternates: 
+  - syntax: '.cssContainer({"*CSS_PROPERTY_1*":"*VALUE_1*", "*CSS_PROPERTY_2*":"*VALUE_2*"})'
     description: Apply multiple CSS property and value pairs by using curly brackets and colons.
 notes: true
 related:

--- a/reference/_standard-element-commands/standard-disable.md
+++ b/reference/_standard-element-commands/standard-disable.md
@@ -2,22 +2,18 @@
 title: standard.disable
 command_type: action
 relevant_elements: [Audio, Button, Controller, DropDown, Key, MediaRecorder, Scale, Selector, TextInput, Timer, Tooltip, Video, Youtube]
-syntax: getX("*ELEMENT_NAME*").disable()
+syntax: .disable()
 description: Disables any interactive feature of the element.
-notes: true
 related:
-  - command: standard.enable
+  - name: standard.enable
     collection: standard-element-commands
   - command: audio.disable
     collection: audio
-  - command: selector.disableClicks
+  - name: selector.disableClicks
     collection: selector
   - command: video.disable
     collection: video
 ---
-
-
-<!--more-->
 
 <pre><code class="language-diff-javascript diff-highlight">
 @// example

--- a/reference/_standard-element-commands/standard-enable.md
+++ b/reference/_standard-element-commands/standard-enable.md
@@ -2,7 +2,7 @@
 title: standard.enable
 command_type: action
 relevant_elements: [Audio, Button, Controller, DropDown, Key, MediaRecorder, Scale, Selector, TextInput, Timer, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").enable()
+syntax: .enable()
 description: Enables any interactive feature that was previously disabled.
 related:
   - name: standard.disable

--- a/reference/_standard-element-commands/standard-hidden.md
+++ b/reference/_standard-element-commands/standard-hidden.md
@@ -2,7 +2,7 @@
 title: standard.hidden
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("*ELEMENT_NAME*").hidden()
+syntax: .hidden()
 description: Hides an element. If the element is printed, it occupies space on the screen but its content is not visible.
 related:
   - name: standard.visible

--- a/reference/_standard-element-commands/standard-left.md
+++ b/reference/_standard-element-commands/standard-left.md
@@ -2,8 +2,8 @@
 title: standard.left
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").left()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .left()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-log.md
+++ b/reference/_standard-element-commands/standard-log.md
@@ -1,8 +1,8 @@
 ---
 title: standard.log
 command_type: action
-syntax: getX("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-print.md
+++ b/reference/_standard-element-commands/standard-print.md
@@ -2,8 +2,8 @@
 title: standard.print
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").print()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .print()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-refresh.md
+++ b/reference/_standard-element-commands/standard-refresh.md
@@ -2,8 +2,8 @@
 title: standard.refresh
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").refresh()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .refresh()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-remove.md
+++ b/reference/_standard-element-commands/standard-remove.md
@@ -2,8 +2,8 @@
 title: standard.remove
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").remove()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .remove()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-right.md
+++ b/reference/_standard-element-commands/standard-right.md
@@ -2,8 +2,8 @@
 title: standard.right
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").right()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .right()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-scaling.md
+++ b/reference/_standard-element-commands/standard-scaling.md
@@ -2,8 +2,8 @@
 title: standard.scaling
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").scaling()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .scaling()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-selector.md
+++ b/reference/_standard-element-commands/standard-selector.md
@@ -2,8 +2,8 @@
 title: standard.selector
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Selector, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").selector()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .selector()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-setVar.md
+++ b/reference/_standard-element-commands/standard-setVar.md
@@ -2,8 +2,8 @@
 title: standard.setVar
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Function, Html, Image, Key, MediaRecorder, Scale, Selector, Text, TextInput, Timer, Tooltip, Var, Video, Youtube]
-syntax: getX("ELEMENT_NAME").setVar()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .setVar()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-size.md
+++ b/reference/_standard-element-commands/standard-size.md
@@ -2,8 +2,8 @@
 title: standard.size
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").size()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .size()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-test.printed.md
+++ b/reference/_standard-element-commands/standard-test.printed.md
@@ -2,8 +2,8 @@
 title: standard.test.printed
 command_type: test
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").test.printed()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.printed()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_standard-element-commands/standard-visible.md
+++ b/reference/_standard-element-commands/standard-visible.md
@@ -2,8 +2,8 @@
 title: standard.visible
 command_type: action
 relevant_elements: [Audio, Button, Canvas, Controller, DropDown, Html, Image, MediaRecorder, Scale, Text, TextInput, Tooltip, Video, Youtube]
-syntax: getX("ELEMENT_NAME").visible()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .visible()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 related:
   - name: standard.hidden
     collection: standard-element-commands

--- a/reference/_text/text-log.md
+++ b/reference/_text/text-log.md
@@ -1,8 +1,8 @@
 ---
 title: text.log
 command_type: action
-syntax: getText("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_text/text-test.text.md
+++ b/reference/_text/text-test.text.md
@@ -1,8 +1,8 @@
 ---
 title: text.test.text
 command_type: test
-syntax: getText("ELEMENT_NAME").test.text()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.text()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_text/text-text.md
+++ b/reference/_text/text-text.md
@@ -1,8 +1,8 @@
 ---
 title: text.text
 command_type: action
-syntax: getText("ELEMENT_NAME").text()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .text()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_text/text-unfold.md
+++ b/reference/_text/text-unfold.md
@@ -1,8 +1,8 @@
 ---
 title: text.unfold
 command_type: action
-syntax: getText("ELEMENT_NAME").unfold()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .unfold()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_textinput/textinput-length.md
+++ b/reference/_textinput/textinput-length.md
@@ -1,8 +1,8 @@
 ---
 title: textinput.length
 command_type: action
-syntax: getTextInput("ELEMENT_NAME").length()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .length()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_textinput/textinput-lines.md
+++ b/reference/_textinput/textinput-lines.md
@@ -1,8 +1,8 @@
 ---
 title: textinput.lines
 command_type: action
-syntax: getTextInput("ELEMENT_NAME").lines()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .lines()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_textinput/textinput-log.md
+++ b/reference/_textinput/textinput-log.md
@@ -1,8 +1,8 @@
 ---
 title: textinput.log
 command_type: action
-syntax: getTextInput("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_textinput/textinput-once.md
+++ b/reference/_textinput/textinput-once.md
@@ -1,8 +1,8 @@
 ---
 title: textinput.once
 command_type: action
-syntax: getTextInput("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_textinput/textinput-test.text.md
+++ b/reference/_textinput/textinput-test.text.md
@@ -1,8 +1,8 @@
 ---
 title: textinput.test.text
 command_type: test
-syntax: getTextInput("ELEMENT_NAME").test.text()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.text()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_textinput/textinput-text.md
+++ b/reference/_textinput/textinput-text.md
@@ -1,8 +1,8 @@
 ---
 title: textinput.text
 command_type: action
-syntax: getTextInput("ELEMENT_NAME").text()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .text()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_textinput/textinput-wait.md
+++ b/reference/_textinput/textinput-wait.md
@@ -1,8 +1,8 @@
 ---
 title: textinput.wait
 command_type: action
-syntax: getTextInput("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-callback.md
+++ b/reference/_timer/timer-callback.md
@@ -1,8 +1,8 @@
 ---
 title: timer.callback
 command_type: action
-syntax: getTimer("ELEMENT_NAME").callback()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .callback()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-log.md
+++ b/reference/_timer/timer-log.md
@@ -1,8 +1,8 @@
 ---
 title: timer.log
 command_type: action
-syntax: getTimer("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-pause.md
+++ b/reference/_timer/timer-pause.md
@@ -1,8 +1,8 @@
 ---
 title: timer.pause
 command_type: action
-syntax: getTimer("ELEMENT_NAME").pause()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .pause()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-resume.md
+++ b/reference/_timer/timer-resume.md
@@ -1,8 +1,8 @@
 ---
 title: timer.resume
 command_type: action
-syntax: getTimer("ELEMENT_NAME").resume()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .resume()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-set.md
+++ b/reference/_timer/timer-set.md
@@ -1,8 +1,8 @@
 ---
 title: timer.set
 command_type: action
-syntax: getTimer("ELEMENT_NAME").set()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .set()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-start.md
+++ b/reference/_timer/timer-start.md
@@ -1,8 +1,8 @@
 ---
 title: timer.start
 command_type: action
-syntax: getTimer("ELEMENT_NAME").start()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .start()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-stop.md
+++ b/reference/_timer/timer-stop.md
@@ -1,8 +1,8 @@
 ---
 title: timer.stop
 command_type: action
-syntax: getTimer("ELEMENT_NAME").stop()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .stop()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-test.ended.md
+++ b/reference/_timer/timer-test.ended.md
@@ -1,8 +1,8 @@
 ---
 title: timer.test.ended
 command_type: test
-syntax: getTimer("ELEMENT_NAME").test.ended()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.ended()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-test.running.md
+++ b/reference/_timer/timer-test.running.md
@@ -1,8 +1,8 @@
 ---
 title: timer.test.running
 command_type: test
-syntax: getTimer("ELEMENT_NAME").test.running()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.running()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_timer/timer-wait.md
+++ b/reference/_timer/timer-wait.md
@@ -1,8 +1,8 @@
 ---
 title: timer.wait
 command_type: action
-syntax: getTimer("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_tooltip/tooltip-frame.md
+++ b/reference/_tooltip/tooltip-frame.md
@@ -1,8 +1,8 @@
 ---
 title: tooltip.frame
 command_type: action
-syntax: getTooltip("ELEMENT_NAME").frame()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .frame()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_tooltip/tooltip-key.md
+++ b/reference/_tooltip/tooltip-key.md
@@ -1,8 +1,8 @@
 ---
 title: tooltip.key
 command_type: action
-syntax: getTooltip("ELEMENT_NAME").key()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .key()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_tooltip/tooltip-label.md
+++ b/reference/_tooltip/tooltip-label.md
@@ -1,8 +1,8 @@
 ---
 title: tooltip.label
 command_type: action
-syntax: getTooltip("ELEMENT_NAME").label()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .label()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_tooltip/tooltip-log.md
+++ b/reference/_tooltip/tooltip-log.md
@@ -1,8 +1,8 @@
 ---
 title: tooltip.log
 command_type: action
-syntax: getTooltip("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_tooltip/tooltip-position.md
+++ b/reference/_tooltip/tooltip-position.md
@@ -1,8 +1,8 @@
 ---
 title: tooltip.position
 command_type: action
-syntax: getTooltip("ELEMENT_NAME").position()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .position()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_tooltip/tooltip-print.md
+++ b/reference/_tooltip/tooltip-print.md
@@ -1,8 +1,8 @@
 ---
 title: tooltip.print
 command_type: action
-syntax: getTooltip("ELEMENT_NAME").print()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .print()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_tooltip/tooltip-text.md
+++ b/reference/_tooltip/tooltip-text.md
@@ -1,8 +1,8 @@
 ---
 title: tooltip.text
 command_type: action
-syntax: getTooltip("ELEMENT_NAME").text()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .text()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_tooltip/tooltip-wait.md
+++ b/reference/_tooltip/tooltip-wait.md
@@ -1,8 +1,8 @@
 ---
 title: tooltip.wait
 command_type: action
-syntax: getTooltip("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_var/var-global.md
+++ b/reference/_var/var-global.md
@@ -1,8 +1,8 @@
 ---
 title: var.global
 command_type: action
-syntax: getVar("ELEMENT_NAME").global()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .global()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_var/var-local.md
+++ b/reference/_var/var-local.md
@@ -1,8 +1,8 @@
 ---
 title: var.local
 command_type: action
-syntax: getVar("ELEMENT_NAME").local()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .local()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_var/var-log.md
+++ b/reference/_var/var-log.md
@@ -1,8 +1,8 @@
 ---
 title: var.log
 command_type: action
-syntax: getVar("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_var/var-set.md
+++ b/reference/_var/var-set.md
@@ -1,8 +1,8 @@
 ---
 title: var.set
 command_type: action
-syntax: getVar("ELEMENT_NAME").set()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .set()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_var/var-test.is.md
+++ b/reference/_var/var-test.is.md
@@ -1,8 +1,8 @@
 ---
 title: var.test.is
 command_type: test
-syntax: getVar("ELEMENT_NAME").test.is()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.is()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-disable.md
+++ b/reference/_video/video-disable.md
@@ -1,8 +1,8 @@
 ---
 title: video.disable
 command_type: action
-syntax: getVideo("ELEMENT_NAME").disable()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .disable()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-log.md
+++ b/reference/_video/video-log.md
@@ -1,8 +1,8 @@
 ---
 title: video.log
 command_type: action
-syntax: getVideo("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-once.md
+++ b/reference/_video/video-once.md
@@ -1,8 +1,8 @@
 ---
 title: video.once
 command_type: action
-syntax: getVideo("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-pause.md
+++ b/reference/_video/video-pause.md
@@ -1,8 +1,8 @@
 ---
 title: video.pause
 command_type: action
-syntax: getVideo("ELEMENT_NAME").pause()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .pause()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-play.md
+++ b/reference/_video/video-play.md
@@ -1,8 +1,8 @@
 ---
 title: video.play
 command_type: action
-syntax: getVideo("ELEMENT_NAME").play()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .play()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-print.md
+++ b/reference/_video/video-print.md
@@ -1,8 +1,8 @@
 ---
 title: video.print
 command_type: action
-syntax: getVideo("ELEMENT_NAME").print()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .print()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-remove.md
+++ b/reference/_video/video-remove.md
@@ -1,8 +1,8 @@
 ---
 title: video.remove
 command_type: action
-syntax: getVideo("ELEMENT_NAME").remove()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .remove()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-stop.md
+++ b/reference/_video/video-stop.md
@@ -1,8 +1,8 @@
 ---
 title: video.stop
 command_type: action
-syntax: getVideo("ELEMENT_NAME").stop()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .stop()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-test.hasPlayed.md
+++ b/reference/_video/video-test.hasPlayed.md
@@ -1,8 +1,8 @@
 ---
 title: video.test.hasPlayed
 command_type: test
-syntax: getVideo("ELEMENT_NAME").test.hasPlayed()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.hasPlayed()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-test.playing.md
+++ b/reference/_video/video-test.playing.md
@@ -1,8 +1,8 @@
 ---
 title: video.test.playing
 command_type: test
-syntax: getVideo("ELEMENT_NAME").test.playing()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.playing()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_video/video-wait.md
+++ b/reference/_video/video-wait.md
@@ -1,8 +1,8 @@
 ---
 title: video.wait
 command_type: action
-syntax: getVideo("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_youtube/youtube-log.md
+++ b/reference/_youtube/youtube-log.md
@@ -1,8 +1,8 @@
 ---
 title: youtube.log
 command_type: action
-syntax: getYoutube("ELEMENT_NAME").log()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .log()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_youtube/youtube-once.md
+++ b/reference/_youtube/youtube-once.md
@@ -1,8 +1,8 @@
 ---
 title: youtube.once
 command_type: action
-syntax: getYoutube("ELEMENT_NAME").once()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .once()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_youtube/youtube-pause.md
+++ b/reference/_youtube/youtube-pause.md
@@ -1,8 +1,8 @@
 ---
 title: youtube.pause
 command_type: action
-syntax: getYoutube("ELEMENT_NAME").pause()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .pause()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_youtube/youtube-play.md
+++ b/reference/_youtube/youtube-play.md
@@ -1,8 +1,8 @@
 ---
 title: youtube.play
 command_type: action
-syntax: getYoutube("ELEMENT_NAME").play()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .play()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_youtube/youtube-stop.md
+++ b/reference/_youtube/youtube-stop.md
@@ -1,8 +1,8 @@
 ---
 title: youtube.stop
 command_type: action
-syntax: getYoutube("ELEMENT_NAME").stop()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .stop()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_youtube/youtube-test.hasPlayed.md
+++ b/reference/_youtube/youtube-test.hasPlayed.md
@@ -1,8 +1,8 @@
 ---
 title: youtube.test.hasPlayed
 command_type: test
-syntax: getYoutube("ELEMENT_NAME").test.hasPlayed()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.hasPlayed()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_youtube/youtube-test.playing.md
+++ b/reference/_youtube/youtube-test.playing.md
@@ -1,8 +1,8 @@
 ---
 title: youtube.test.playing
 command_type: test
-syntax: getYoutube("ELEMENT_NAME").test.playing()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .test.playing()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript

--- a/reference/_youtube/youtube-wait.md
+++ b/reference/_youtube/youtube-wait.md
@@ -1,8 +1,8 @@
 ---
 title: youtube.wait
 command_type: action
-syntax: getYoutube("ELEMENT_NAME").wait()
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+syntax: .wait()
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 ---
 
 ```javascript


### PR DESCRIPTION
+ Fix display of alternate command syntax
+ Change `command.html` and `element.html`: reorganize layouts, change display of "SYNTAX" section, add parameters list
+ Remove `optional_parameters` tag and replace with `parameters.optional` tag
+ Shorten "Lorem ipsum" placeholder text in element commands