### PR TITLE
Dev jeremy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ logo: "/assets/images/pcibex-logo.png"
 # Aux links for the upper right navigation
 aux_links:
   "Go to the PCIbex Farm":
-    - "https://expt.pcibex.net/"
+    - "https://farm.pcibex.net/"
 # Makes Aux links open in a new tab. Default is false
 aux_links_new_tab: true
 plugins:
@@ -213,13 +213,13 @@ defaults:
       path: "reference/_deprecated"
     values:
       layout: "command"
-      grand_parent: "⚠ Deprecated features"    
+      grand_parent: "⚠ Deprecated features"
   - scope:
       path: "reference/_how-to-guides"
     values:
       layout: "how-to-guide"
       parent: "How-to guides"
-      grand_parent: "Support"
+      # grand_parent: "Support"
   - scope:
       path: "reference/_global-commands"
     values:

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -186,7 +186,7 @@
         {% endif %}
       {% endif %}
     {%- endif -%}
-    {%- if  node.title == "Announcements" or node.title == "Advanced Tutorial" or node.title == "Commands" -%}
+    {%- if  node.title == "Announcements" or node.title == "How-to guides" or node.title == "Commands" -%}
       <hr class="mt-2 mb-2 ml-3 mr-3">
     {%- endif -%}
   {%- endfor -%}

--- a/advanced-tutorial/10_counterbalancing.md
+++ b/advanced-tutorial/10_counterbalancing.md
@@ -207,7 +207,7 @@ Other options for controlling group assignment:
 To modify the experiment URL, replace `experiment.html` with `server.py?withsquare=N`, where `N` is a number from 0 to number-of-groups-minus-one. This method is useful if you are sending the URL around for data collection but want to control which group your participants end up in.
 
 For example, the **AdvancedTutorial** experiment has two groups.  
-  + If a participant clicks the default URL `https://expt.pcibex.net/ibexexps/angelicapan/AdvancedTutorial/experiment.html`, then they will be assigned to group `A` or `B` depending on the internal counter.
-  + If a participant clicks the link `https://expt.pcibex.net/ibexexps/angelicapan/AdvancedTutorial/server.py?withsquare=0`, then they will be assigned to group `A`.
-  + If a participant clicks the link `https://expt.pcibex.net/ibexexps/angelicapan/AdvancedTutorial/server.py?withsquare=1`, then they will be assigned to group `B`.
+  + If a participant clicks the default URL `https://farm.pcibex.net/p/qkybME/experiment.html`, then they will be assigned to group `A` or `B` depending on the internal counter.
+  + If a participant clicks the link `https://farm.pcibex.net/p/qkybME/server.py?withsquare=0`, then they will be assigned to group `A`.
+  + If a participant clicks the link `https://farm.pcibex.net/p/qkybME/server.py?withsquare=1`, then they will be assigned to group `B`.
 

--- a/advanced-tutorial/9_customizing-experiment.md
+++ b/advanced-tutorial/9_customizing-experiment.md
@@ -12,18 +12,18 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 ## Selecting an image with a mouse click
 
-The participant selects an image by pressing the `F` or `J` key. We'll include the option of clicking on an image to select it by using a [**Selector**]({{site.baseurl}}/elements/selector)}. 
+The participant selects an image by pressing the `F` or `J` key. We'll include the option of clicking on an image to select it by using a [**Selector**]({{site.baseurl}}/elements/selector). 
 
 A **Selector** creates a group of elements, where (by default) each member can be selected with a mouse click. We can then associate a key to each member, so that a keypress will also select the desired element. 
 
 {% capture instructions %}
 + Remove the `"keypress"` `Key`.
-+ Create a [**Selector**]({{site.baseurl}}/elements/selector)} named `"selection"`.
-  1. Call the [`add`]({{site.baseurl}}/elements/selector/selector-add)} command to add the `"singular"` and `"plural"` `Image` elements
-  2. Call the [`keys`]({{site.baseurl}}/elements/selector/selector-keys)} command to associate the `F` and `J` keys to the singular image and plural image, respectively. 
-  3. Call the [`log`]({{site.baseurl}}/elements/selector/selector-log)} command to log information about the participant's selection.
-  4. Call the [`once`]({{site.baseurl}}/elements/selector/selector-once)} command so that only the first image selection is valid (without the `once` command, the participant can change the selected image, up until the trial ends).
-  5. Call the [`wait`]({{site.baseurl}}/elements/selector/selector-wait)} command to pause experiment script execution until the participant selects an element.
++ Create a [**Selector**]({{site.baseurl}}/elements/selector) named `"selection"`.
+  1. Call the [`add`]({{site.baseurl}}/elements/selector/selector-add) command to add the `"singular"` and `"plural"` `Image` elements
+  2. Call the [`keys`]({{site.baseurl}}/elements/selector/selector-keys) command to associate the `F` and `J` keys to the singular image and plural image, respectively. 
+  3. Call the [`log`]({{site.baseurl}}/elements/selector/selector-log) command to log information about the participant's selection.
+  4. Call the [`once`]({{site.baseurl}}/elements/selector/selector-once) command so that only the first image selection is valid (without the `once` command, the participant can change the selected image, up until the trial ends).
+  5. Call the [`wait`]({{site.baseurl}}/elements/selector/selector-wait) command to pause experiment script execution until the participant selects an element.
 
 *If you are copy and pasting this code, delete any lines highlighted with a red background.*
 <pre><code class="language-diff-javascript diff-highlight"> 
@@ -76,7 +76,7 @@ A **Selector** creates a group of elements, where (by default) each member can b
 
 ## Creating a timeout
 
-The `"experimental-trial"` trial ends after audio playback finishes or a valid keypress, [whichever comes second]({{site.baseurl}}/basic-tutorial/#option3)}.
+The `"experimental-trial"` trial ends after audio playback finishes or a valid keypress, [whichever comes second]({{site.baseurl}}/basic-tutorial/#option3).
 
 We'll modify the trial so that it ends after whichever comes *first*:
 
@@ -87,10 +87,10 @@ In other words, the participant has until the audio playback finishes to press a
 
 {% capture instructions %}
 + Create a timeout:
-  1. Create and start a [`Timer`]({{site.baseurl}}/elements/timer)} named `"timeout"` that is `row.duration` ms long.
-  2. Call the [`callback`]({{site.baseurl}}/elements/selector/selector-callback)} command on the `"selection"` **Selector**. When an image is selected, the `callback` command will stop the `"timeout"` `Timer`. Remove the `once` and `wait` commands.
-  3. Call the [`wait`]({{site.baseurl}}/elements/timer/timer-wait)} command on the `"timeout"` `Timer` to pause experiment script execution until the timer stops.
-  4. Call the [`stop`]({{site.baseurl}}/elements/audio/audio-stop)} command on the `"audio"` `Audio` to stop audio playback when the timer stops. Remove the `wait("first")` command.
+  1. Create and start a [`Timer`]({{site.baseurl}}/elements/timer) named `"timeout"` that is `row.duration` ms long.
+  2. Call the [`callback`]({{site.baseurl}}/elements/selector/selector-callback) command on the `"selection"` **Selector**. When an image is selected, the `callback` command will stop the `"timeout"` `Timer`. Remove the `once` and `wait` commands.
+  3. Call the [`wait`]({{site.baseurl}}/elements/timer/timer-wait) command on the `"timeout"` `Timer` to pause experiment script execution until the timer stops.
+  4. Call the [`stop`]({{site.baseurl}}/elements/audio/audio-stop) command on the `"audio"` `Audio` to stop audio playback when the timer stops. Remove the `wait("first")` command.
 
 *If you are copy and pasting this code, delete any lines highlighted with a red background.*
 
@@ -165,7 +165,7 @@ The timeout is created as follows:
 Each trial begins as soon as the previous trial ends. This might be overwhelming for participants, so we'll create a one-second pause between trials. 
 
 {% capture instructions %}
-Create and start a `Timer` named `"break"` that is 1000ms long. Call the [`wait`]({{site.baseurl}}/elements/timer/timer-wait)} command to pause experiment script execution until the timer stops:
+Create and start a `Timer` named `"break"` that is 1000ms long. Call the [`wait`]({{site.baseurl}}/elements/timer/timer-wait) command to pause experiment script execution until the timer stops:
 
 <pre><code class="language-diff-javascript diff-highlight"> 
 @// code omitted in interest of space
@@ -320,17 +320,17 @@ With the `cssContainer` command:
 
 We'll add a completion screen trial to the end of the experiment.
 
-By default, PennController sends the experiment results to the PCIbex Farm server after all the trials have ended. Use the global command [`SendResults`]({{site.baseurl}}/commands/global-commands/sendresults)} to manually control when PennController sends results, and send results *before* the completion screen trial begins. This will help ensure that participants don't close their web browser before the experiment results are sent and saved.
+By default, PennController sends the experiment results to the PCIbex Farm server after all the trials have ended. Use the global command [`SendResults`]({{site.baseurl}}/commands/global-commands/sendresults) to manually control when PennController sends results, and send results *before* the completion screen trial begins. This will help ensure that participants don't close their web browser before the experiment results are sent and saved.
 
 We'll create a `Button` and call the `wait` command on it to pause experiment script execution, so that participants have time to read the completion screen trial. 
 
 However, there is no need for participants to go beyond this trial; the experiment is already over, and the results have already been sent. Pause experiment script execution indefinitely by calling the `wait` command on the `Button` *without* printing it. The participant will never be able to click the button, and the `wait` command will never be satisfied.
 
 {% capture instructions %}
-+ Call the [`SendResults`]({{site.baseurl}}/global-commands/sendresults)} global command and label it `"send"`.
++ Call the [`SendResults`]({{site.baseurl}}/global-commands/sendresults) global command and label it `"send"`.
 + Create a new trial labeled `"completion_screen"`.
   + Create and print a centered `Text` named `"thanks"`.
-  + Create a new `Button` named `"void"`. Call the [`wait`]({{site.baseurl}}/elements/button/button-wait)} command on it, but do *not* print it to the screen.
+  + Create a new `Button` named `"void"`. Call the [`wait`]({{site.baseurl}}/elements/button/button-wait) command on it, but do *not* print it to the screen.
 
 <pre><code class="language-diff-javascript diff-highlight"> 
 @// code omitted in interest of space

--- a/basic-tutorial/7_wrapping-up.md
+++ b/basic-tutorial/7_wrapping-up.md
@@ -99,4 +99,4 @@ Now that you've learned the basics of PennController, we recommend reading the [
 + Create obligatory checkboxes and global variables.
 + Examine PennController results files.
 
-You can also jump right in and [start creating your own experiments](https://expt.pcibex.net/){:target="_blank"}. If you have questions, visit the [**Troubleshooting**]({{site.baseurl}}/docs/troubleshooting) page, check out our [**How-to guides**]({{site.baseurl}}/docs/how-to-guides), or post a question on our [support forum](https://farm.pcibex.net/experiments/new){:target="_blank"}.
+You can also jump right in and [start creating your own experiments](https://farm.pcibex.net/){:target="_blank"}. If you have questions, visit the [**Troubleshooting**]({{site.baseurl}}/docs/troubleshooting) page, check out our [**How-to guides**]({{site.baseurl}}/docs/how-to-guides), or post a question on our [support forum](https://farm.pcibex.net/experiments/new){:target="_blank"}.

--- a/docs/advanced-tutorial.md
+++ b/docs/advanced-tutorial.md
@@ -39,7 +39,7 @@ In the **Advanced Tutorial**, you'll learn how to make a picture matching experi
 Preview the **AdvancedTutorial** experiment:
 
 <p class="text-delta collapsible-block-title">
-  <a href="https://expt.pcibex.net/ibexexps/angelicapan/AdvancedTutorial/experiment.html" target="_blank">Click to take the experiment</a>
+  <a href="https://farm.pcibex.net/r/AeTXMk/experiment.html" target="_blank">Click to take the experiment</a>
 </p> 
 
 {% capture content %}

--- a/docs/basic-tutorial.md
+++ b/docs/basic-tutorial.md
@@ -32,7 +32,7 @@ experiment with the following structure:
 Preview the **BasicTutorial** experiment:
 
 <p class="text-delta collapsible-block-title">
-  <a href="https://expt.pcibex.net/ibexexps/angelicapan/BasicTutorial/experiment.html" target="_blank">
+  <a href="https://farm.pcibex.net/r/QuFrkC/experiment.html" target="_blank">
     Click to take the experiment
   </a>
 </p>

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,7 @@
 ---
 title: Commands
 permalink: /commands/
-nav_order: 7
+nav_order: 8
 ---
 
 # {{ page.title }}

--- a/docs/current-version.md
+++ b/docs/current-version.md
@@ -2,5 +2,6 @@
 title: PennController 1.9
 permalink: /current-version/
 redirect_internal: announcements/2020-12-16-penncontroller-1-9/
+has_children: true
 nav_order: 10
 ---

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -2,8 +2,8 @@
 layout: default
 title: ⚠ Deprecated features
 permalink: /deprecated/
-nav_order: 9
 blurb: This page lists deprecated elements and commands.
+nav_order: 11
 ---
 
 # {{ page.title }}

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -3,7 +3,7 @@ title: Elements
 permalink: /elements/
 children_collection: elements
 children_code_font: true
-nav_order: 6
+nav_order: 7
 ---
 
 # {{ page.title }}

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -1,6 +1,7 @@
 ---
 title: How-to guides
-nav_order: 2
+permalink: /how-to/
+nav_order: 6
 has_children: true
 has_toc: false
 children_collection: how-to-guides

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,7 +1,7 @@
 ---
 title: Support
 permalink: /support/
-nav_order: 8
+nav_order: 9
 ---
 
 # {{ page.title }}


### PR DESCRIPTION
- Replace expt from main link to farm with farm
- Move How-To to main menu, move Deprecated below last version
- Replace last occurrences of expt with farm in tutorial
- Fix extra }'s that got inserted after some links